### PR TITLE
Remove dot from docname

### DIFF
--- a/svg2fcsketch.py
+++ b/svg2fcsketch.py
@@ -1225,6 +1225,7 @@ else:
     fcstdfile = re.sub('\.svg$', '.fcstd', svgfile, re.I)
 docname = re.sub('\.fcstd$', '', fcstdfile, re.I)
 docname = re.sub('^.*/', '', docname)
+docname = docname.replace('.', '_')
 
 if not options.outfile:
   if sys.stdout.isatty():


### PR DESCRIPTION
In FreeCAD 0.18.14796 (Git), the sketch is hidden. The probable cause
for this is that FreeCAD replaces the '.' (dot) in the object name in
Document.xml but not in GuiDocument.xml.